### PR TITLE
setup the env variables to read from .env file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 # Use Python 3.10.12 as the parent image
 FROM python:3.10.12-slim-buster
 
+# Use build arguments to pass sensitive data
+ARG DJANGO_SECRET_KEY
+ARG WEATHERSTACK_API_KEY
+ARG PORT
+ARG DEBUG
+
+# Set environment variables
+ENV DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY
+ENV WEATHERSTACK_API_KEY=$WEATHERSTACK_API_KEY
+ENV PORT=$PORT
+ENV DEBUG=$DEBUG
+
 # Set the working directory in the container
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ You can do it by using a single command:
 pip install -r requirements.txt
 ```
 
+## Setup .env file
+
+Lastly, you need to setup the .env file. The variables are ready on heroku, however they are not ready for local development. That's why you need to setup the .env file to make the project work locally.
+
+Create the .env file inside the root of the project.
+
+Open it, and paste this into it:
+
+```plaintext
+DJANGO_SECRET_KEY=django_secret_value_value
+WEATHERSTACK_API_KEY=weatherstack_api_key_value
+PORT=8000
+DEBUG=True or False
+```
+
+Replace the values with the real values of these variables, you can find them here: https://github.com/tomasszyszkowicz/WeatherApp/settings/variables/actions
+
+Set the DEBUG to True for development. But if you want to test how the app will run in production, set the DEBUG to False.
+
 ## Run server
 
 To run the project locally on your localhost you can do this:

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
- sudo docker build -t weather-app .
- sudo docker run -p 8000:8000 weather-app
+args=()
+while IFS= read -r line; do
+  args+=(--build-arg "$line")
+done < ./.env
+
+docker build "${args[@]}" -t weather-app .
+docker run -p 8000:8000 weather-app

--- a/dataAPI/utility/weatherstack/weatherstack_api_calls.py
+++ b/dataAPI/utility/weatherstack/weatherstack_api_calls.py
@@ -5,8 +5,7 @@ import requests
 import json
 from django.http import HttpRequest, HttpResponse, JsonResponse
 import plotly.graph_objs as go
-
-import plotly.graph_objs as go
+import os
 
 
 class APICall:

--- a/weather_app/settings.py
+++ b/weather_app/settings.py
@@ -21,10 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-#4%v6+j8vyk!n6oj+o0u31i7(#tyw@8i6t-=gl&y#k=7nx=&vv'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG")
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "forecast-genius-e37be46199d1.herokuapp.com"]
 


### PR DESCRIPTION
The .env setup was created. Now there is a need to setup the .env file for local development, build.sh now reads the .env file when building the docker image. README was updated accordingly. and some other slight changes had to be made